### PR TITLE
Add async e2e, to api and tests configuration

### DIFF
--- a/end-to-end/api.md
+++ b/end-to-end/api.md
@@ -217,6 +217,17 @@ Receives multiple messages and expected phrases in an object array. The goal of 
 	}
 	```
 
+* **Success Response (async mode):**
+
+
+  * **Code:** 200 <br />
+    **Content:**
+	```javascript
+	{
+	    "conversation_id": "string",
+	}
+	```
+
 * **Error Response:**
 	* **Code:** 400 BAD REQUEST <br />
     **Content:** `"Invalid message"`

--- a/end-to-end/api.md
+++ b/end-to-end/api.md
@@ -175,6 +175,8 @@ Receives multiple messages and expected phrases in an object array. The goal of 
 
    `voice_id=[string]`: one of Amazon Polly's supported voices (e.g. Joey, Vicki, Hans, etc.). Default value: "Joey". MUST correspond with the language_code. Taken from: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html
 
+   `async=[boolean]`: process the messages in the background, results can be obtained in the conversation endpoint. Default value: "false".
+
 * **Data Params**
 
    **Required:**
@@ -247,3 +249,78 @@ Receives multiple messages and expected phrases in an object array. The goal of 
 * **Notes:**
 
   * Not sending the language_code or voice_id will default **both** to en-US and Joey.
+
+
+## **Conversation** Endpoint
+
+Obtains the processed results from a batch process sent in async mode
+
+* **URL**
+
+  /conversation
+
+* **Method:**
+
+ `POST`
+
+*  **URL Params**
+
+   **Required:**
+
+      `uuid=[string]`: the id of the conversation, returned by the Batch process when async mode param is set to true
+
+* **Success Response:**
+
+
+  * **Code:** 200 <br />
+    **Content:**
+	```javascript
+	{
+	    "results": [
+          {
+              "streamURL": "string",
+              "sessionTimeout": 0,
+              "transcriptAudioURL": "string",
+              "message": "string",
+              "transcript": "string",
+              "card": {
+                  "subTitle": "string",
+                  "mainTitle": "string",
+                  "textField": "string",
+                  "type": "string",
+                  "imageURL": "string"
+              }
+          }
+	    ]
+	}
+	```
+
+* **Error Response:**
+  * **Code:** 500 INTERNAL SERVER ERROR <br />
+    **Content:** `{error: 'error message in case of an exception'}`
+
+* **Sample Call:**
+
+    ```javascript
+    const userId = <your user id>;
+    const voiceId = "Joey";
+    const languageCode = "en-US":
+
+    $.post(`https://virtual-device.bespoken.io/batch_process?user_id=${userId}&voice_id=${voiceId}&language_code=${languageCode}&async=true`,
+    {
+        "messages": [
+            {"text":"open guess the price", "phrases":["how many persons"]},
+            {"text":"one"}
+        ]
+    },
+    function(data, status){
+        console.log("Got conversation id: " + data.conversation_id);
+
+        // Logic implementation to wait for a number of seconds
+
+        $.post(`https://virtual-device.bespoken.io/conversation?uuid={uuid},
+        function(convData, convStatus){
+            console.log("Got: " + convData.results.length + " responses!");
+        });
+    });
+    ```

--- a/end-to-end/api.md
+++ b/end-to-end/api.md
@@ -175,7 +175,7 @@ Receives multiple messages and expected phrases in an object array. The goal of 
 
    `voice_id=[string]`: one of Amazon Polly's supported voices (e.g. Joey, Vicki, Hans, etc.). Default value: "Joey". MUST correspond with the language_code. Taken from: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html
 
-   `async=[boolean]`: process the messages in the background, results can be obtained in the conversation endpoint. Default value: "false".
+   `async_mode=[boolean]`: process the messages in the background, results can be obtained in the conversation endpoint. Default value: "false".
 
 * **Data Params**
 

--- a/end-to-end/guide.md
+++ b/end-to-end/guide.md
@@ -104,12 +104,15 @@ An example `testing.json` file for end-to-end tests:
 
 Below the end-to-end testing configuration options and what they do are listed:
 
+* [asyncE2EWaitInterval] - Set an interval in milliseconds to wait before querying for new results, when batchEnabled is set to false - defaults to 5000
+* [batchEnabled] - Indicates if we wait for the complete set of utterances in a test to finish or if we query for the results multiple times - defaults to true
 * [filter](#filtering-during-test) - The (optional) path to a class that can be used to override value on the request and response
 * [findReplace](#findreplace) - Values that will be replaced in the scripts before execution
 * [homophones](#homophones) - Values that will be replaced in actual responses from the virtual device
 * html - Generate a pretty HTML report of test results - defaults to `true`
 * [include and exclude](#including-or-excluding-tests-using-tags) - Runs or Skip the tests having the particular specified tags
 * locales - The locale or locales to be used - a comma-delimited list
+* [maxAsyncE2EResponseWaitTime] - Set an interval in milliseconds to wait before stop looking for new results, when batchEnabled is set to false - defaults to 15000
 * platform - The platform that is being tested - can be either `alexa` or `google` - defaults to `alexa`
 * skillId - For tests of type `simulation`, the skillId must be specified
 * stage - For tests of type `simulation`, the stage must be specified - can be `development` or `live`
@@ -117,6 +120,7 @@ Below the end-to-end testing configuration options and what they do are listed:
 * [trace](#viewing-response-payloads) - Causes request and response JSON payloads from the skill to be printed to the console
 * [virtualDeviceToken](../setup) - For end-to-end tests that use virtual devices, this must be specified. 
 [Get one here](../setup)
+
 
 To override [Jest options](https://facebook.github.io/jest/docs/en/configuration.html), just set them under the "jest" key.
 
@@ -415,43 +419,17 @@ That is done with a collection of expected values, such as this:
 
 When a collection is used like this, if any of the values matches, the assertion will be considered a success.
 
-## Goto And Exit
-One advanced feature is support for `goto` and `exit`.
-
-Goto comes at the end of an assertion - if the assertion is true, the test will "jump" to the utterance named.
-Unlike regular assertions, ones that end in "goto" will not be deemed a failure if the comparison part of the assertion is not true.
-
-For example:
-```
----
-- test: Goes to successfully
-- open my skill:
-  - prompt == "Here's your fact" goto Get New Fact
-  - cardContent == /.*/
-  - exit
-- Help:
-  - response.outputSpeech.ssml == "Here's your fact:*"
-  - response.reprompt == undefined
-  - response.card.content =~ /.*/
-- Get New Fact:
-  - response.outputSpeech.ssml == "ABC"
-  - response.reprompt == undefined
-  - response.card.content =~ /.*/
-```
-
-In this case, if the outputSpeech starts with "Here's your fact",
-the test will jump to the last interaction and say "Get New Fact".
-
-If the outputSpeech does not start with "Get New Fact", the other assertions will be evaluated.
-The test will end when it reaches the `exit` statement at the end (no further interactions will be processed).
-
-Using `goto` and `exit`, more complex tests can be built.
-
 # Test Execution
 ## Test Sequence
 Tests are run in the order they appear in the file.
 
 End-to-end tests are not run in parallel, unlike unit tests. This is because of limitations in how the virtual devices work. This is also true for tests that are run using SMAPI Simulations.
+
+## Batch or Sequential Tests
+Tests are run by default in batch. This means that all the utterances are sent to be processed and once they are we return the complete result.
+Setting the "batchEnabled" property to false change this behavior, the utterances will be sent to be processed, and we will run multiple queries to get the results.
+
+The end result will be the same using either of the modes.
 
 ## Skipping Tests
 Label tests "test.only" or "test.skip" to either only run a particular test, or to skip it. Example:


### PR DESCRIPTION
Relates to https://github.com/bespoken/virtual-device-sdk/issues/113 and https://github.com/bespoken/bespoken-docs/issues/27

- Removed goto functionality from the documentation, since it doesn't work for e2e 
- Add the changes to the API to support the batch process in async mode
-  Add the new parameters and functionality for e2e tests (sequential vs batch mode)