### PR TITLE
Reducing address sample to render correctly on mobile

### DIFF
--- a/unit-testing/use-cases.md
+++ b/unit-testing/use-cases.md
@@ -39,7 +39,7 @@ To set the address to be returned from the Address API via mock, just enter a co
 ```yml
 configuration:
   address:
-    addressLine1: 1600 Pennsylvania Avenue, NW
+    addressLine1: 215 Elm Street, NW
     city: Washington
     countryCode: US
     postalCode: 20816


### PR DESCRIPTION
Relates to #69 

<img width="412" alt="Screen Shot 2019-09-10 at 12 20 53 PM" src="https://user-images.githubusercontent.com/8781604/64635542-854dd780-d3c5-11e9-8a79-0ce457479bd5.png">
