### PR TITLE
documentation URL works with or without .html inside the path

### DIFF
--- a/cli/tutorials/debugging-locally.md
+++ b/cli/tutorials/debugging-locally.md
@@ -1,6 +1,6 @@
 ---
 title: WEBSTORM DEBUGGING
-permalink: /tutorials/debugging-locally/
+permalink: /cli/tutorials/debugging-locally/
 ---
 
 # Debugging voice apps locally With Webstorm and Bespoken

--- a/cli/tutorials/tutorial-flask-ask-python.md
+++ b/cli/tutorials/tutorial-flask-ask-python.md
@@ -1,6 +1,6 @@
 ---
 title: PYTHON & FLASK ASK
-permalink: /tutorials/tutorial-flask-ask-python/
+permalink: /cli/tutorials/tutorial-flask-ask-python/
 ---
 
 # Debugging Python voice apps locally with Bespoken

--- a/cli/tutorials/tutorial-lambda-nodejs.md
+++ b/cli/tutorials/tutorial-lambda-nodejs.md
@@ -1,6 +1,6 @@
 ---
 title: NODE.JS & LAMBDA
-permalink: /tutorials/tutorial-lambda-nodejs/
+permalink: /cli/tutorials/tutorial-lambda-nodejs/
 ---
 
 # Debugging your Node voice apps locally Bespoken

--- a/cli/tutorials/tutorial-local-server-java.md
+++ b/cli/tutorials/tutorial-local-server-java.md
@@ -1,6 +1,6 @@
 ---
 title: LOCAL JAVA SERVER
-permalink: /tutorials/tutorial-local-server-java/
+permalink: /cli/tutorials/tutorial-local-server-java/
 ---
 
 # Debugging your Java voice apps locally with Bespoken


### PR DESCRIPTION
relates to 
https://github.com/bespoken/bespoken-docs/issues/81