### PR TITLE
Add bst-proxy to bst tools, and e2e

### DIFF
--- a/cli/commands.md
+++ b/cli/commands.md
@@ -332,12 +332,3 @@ After that, the command will create a "test" directory with all the needed files
 
 You can execute your tests by typing `bst test` on the same command line.
 
-## Use the tools behind a proxy
-
-We support the HTTPS_PROXY environment variable, example:
-
-```
-export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
-```
-
-And then run the command you need.

--- a/cli/commands.md
+++ b/cli/commands.md
@@ -331,3 +331,13 @@ After that, the command will create a "test" directory with all the needed files
 
 
 You can execute your tests by typing `bst test` on the same command line.
+
+## Use the tools behind a proxy
+
+We support the HTTPS_PROXY environment variable, example:
+
+```
+export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
+
+And then run the command you need.

--- a/cli/faq.md
+++ b/cli/faq.md
@@ -33,7 +33,10 @@ On a Mac, open up a terminal and type:
 export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
 ```
 
-For Windows, instructions can be found [here](https://www.computerhope.com/issues/ch000549.htm) 
+On Windows, open up a command line and type: 
+```
+set HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
 
 # Errors
 ## I get an error trying to connect using the bst proxy

--- a/cli/faq.md
+++ b/cli/faq.md
@@ -6,7 +6,7 @@ permalink: /cli/faq/
 # FAQ For Bespoken CLI
 Here are answers to commonly asked questions about our CLI.
 
-# Setup
+# Networking
 ## My organization uses a firewall - how do I use your tools with it?
 Your firewall needs to allow access to the following domains:
 * *.bespoken.io
@@ -23,7 +23,17 @@ We use the following ports for our services:
 * 443
 * 80 (bst proxy only)
 
-Please note - the IP addresses above our subject to change - please contact us via [Gitter](https://gitter.im/bespoken) if you have white-listed all of the above and it is still not working.
+Please note - the IP addresses above are subject to change - please contact us via [Gitter](https://gitter.im/bespoken) if you have white-listed all of the above and are still having problems.
+
+## My organization uses a Proxy - how do I use your tools with it?
+To run our tools through your proxy, you need to set the `HTTPS_PROXY` env variable. 
+
+On a Mac, open up a terminal and type:
+```
+export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
+
+For Windows, instructions can be found [here](https://www.computerhope.com/issues/ch000549.htm) 
 
 # Errors
 ## I get an error trying to connect using the bst proxy

--- a/end-to-end/faq.md
+++ b/end-to-end/faq.md
@@ -446,7 +446,10 @@ On a Mac, open up a terminal and type:
 export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
 ```
 
-For Windows, instructions can be found [here](https://www.computerhope.com/issues/ch000549.htm) 
+On Windows, open up a command line and type: 
+```
+set HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
 
 <!-- Images references -->
 [AlexaHistory]: ./assets/alexaHistory.png "Showing Alexa voice interactions history"

--- a/end-to-end/faq.md
+++ b/end-to-end/faq.md
@@ -417,7 +417,36 @@ It is also possible to specify multiple valid values for a property. That is don
 Alexa AVS doesn't handle more than one request for the same account, if you need to do parallel tests, create the necessary virtual devices using different accounts at the setup.
 
 ## **My Google action responds with  "to let me read out that information turn on personal results in the google app home"**
-Follow [these steps](./setup.html#enable-personal-results-for-google).
+Follow [these steps](./setup.html#enabling-personal-results-for-google).
+
+# Networking
+## My organization uses a firewall - how do I use your tools with it?
+Your firewall needs to allow access to the following domains:
+* *.bespoken.io
+* *.bespoken.tools
+* *.bespoken.link
+
+If white-listing by IP is necessary, the following IPs should be included:
+* 35.244.147.217 (virtual devices)
+* 18.232.68.210 (bst proxy)
+* 34.233.142.145 (other services)
+* 54.221.196.218 (other services)
+
+We use the following ports for our services:
+* 443
+* 80 (bst proxy only)
+
+Please note - the IP addresses above are subject to change - please contact us via [Gitter](https://gitter.im/bespoken) if you have white-listed all of the above and are still having problems.
+
+## My organization uses a Proxy - how do I use your tools with it?
+To run our tools through your proxy, you need to set the `HTTPS_PROXY` env variable. 
+
+On a Mac, open up a terminal and type:
+```
+export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
+
+For Windows, instructions can be found [here](https://www.computerhope.com/issues/ch000549.htm) 
 
 <!-- Images references -->
 [AlexaHistory]: ./assets/alexaHistory.png "Showing Alexa voice interactions history"

--- a/end-to-end/guide.md
+++ b/end-to-end/guide.md
@@ -834,17 +834,6 @@ The following are settings than can help you overcome specific testing issues. H
 | [retryNumber](#retrying-tests) | The number of retrys to execute if a test fails must be in the range [0,5] |
 | virtualDeviceBaseURL | Sets a custom base address for the Virtual Device API endpoints |
 
-
-## Use the tools behind a proxy
-
-We support the HTTPS_PROXY environment variable, example:
-
-```
-export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
-```
-
-And then run bst test.
-
 ## Further Reading
 Take a look at:
 * Our [getting started guide](./getting-started.html)

--- a/end-to-end/guide.md
+++ b/end-to-end/guide.md
@@ -834,6 +834,17 @@ The following are settings than can help you overcome specific testing issues. H
 | [retryNumber](#retrying-tests) | The number of retrys to execute if a test fails must be in the range [0,5] |
 | virtualDeviceBaseURL | Sets a custom base address for the Virtual Device API endpoints |
 
+
+## Use the tools behind a proxy
+
+We support the HTTPS_PROXY environment variable, example:
+
+```
+export HTTPS_PROXY=http://<proxy-url>:<proxy-port>
+```
+
+And then run bst test.
+
 ## Further Reading
 Take a look at:
 * Our [getting started guide](./getting-started.html)


### PR DESCRIPTION
Relates to https://github.com/bespoken/bst/issues/602

Not adding the proxy setting to the unit testing instructions since it should not be needed for local testing.